### PR TITLE
add conda packages to the base environment

### DIFF
--- a/latest/environment.yml
+++ b/latest/environment.yml
@@ -1,7 +1,7 @@
-name: "{{ name }}"
+name: "base"
 channels:
   - defaults
 dependencies:
-  - jupyter
-  - jupyterlab
+# - add packages here
+# - one per line
 prefix: "/opt/conda"


### PR DESCRIPTION
The conda `environment.yml` actually had no effect on the base environment because of the incorrect environment name. A symptom of this was users installing packages via conda that were actually then not available in jupyterlab. 