### PR TITLE
chore: update image versions for release

### DIFF
--- a/R-minimal/.gitlab-ci.yml
+++ b/R-minimal/.gitlab-ci.yml
@@ -15,21 +15,9 @@ image_build:
   before_script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN http://$CI_REGISTRY
   script:
-    - docker pull renku/singleuser:0.3.4-renku0.5.0
+    - docker pull renku/singleuser:0.3.5-renku0.5.2
     - CI_COMMIT_SHA_7=$(echo $CI_COMMIT_SHA | cut -c1-7)
     - docker build --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA_7 .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA_7
   tags:
     - image-build
-
-dot:
-  stage: build
-  image: renku/renku-python:v0.5.0
-  script:
-    - renku log --format dot $(git ls-files --no-empty-directory --recurse-submodules) > graph.dot
-  artifacts:
-    paths:
-      - graph.dot
-  environment:
-    name: dot/$CI_COMMIT_REF_NAME
-    url: $CI_PROJECT_URL/-/jobs/artifacts/$CI_COMMIT_REF_NAME/raw/graph.dot?job=$CI_JOB_NAME

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,8 @@
 -
   folder: python-minimal
   name: Basic Python Project
-  description: The simplest renku project with a basic directory structure and necessary supporting files.
+  description: The simplest Python-based renku project with a basic directory structure and necessary supporting files.
 -
   folder: R-minimal
   name: Basic R Project
+  description: The simplest R-based renku project with a basic directory structure and necessary supporting files.

--- a/python-minimal/.gitlab-ci.yml
+++ b/python-minimal/.gitlab-ci.yml
@@ -15,21 +15,9 @@ image_build:
   before_script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN http://$CI_REGISTRY
   script:
-    - docker pull renku/singleuser:0.3.4-renku0.5.0
+    - docker pull renku/singleuser:0.3.5-renku0.5.2
     - CI_COMMIT_SHA_7=$(echo $CI_COMMIT_SHA | cut -c1-7)
     - docker build --tag $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA_7 .
     - docker push $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA_7
   tags:
     - image-build
-
-dot:
-  stage: build
-  image: renku/renku-python:v0.5.0
-  script:
-    - renku log --format dot $(git ls-files --no-empty-directory --recurse-submodules) > graph.dot
-  artifacts:
-    paths:
-      - graph.dot
-  environment:
-    name: dot/$CI_COMMIT_REF_NAME
-    url: $CI_PROJECT_URL/-/jobs/artifacts/$CI_COMMIT_REF_NAME/raw/graph.dot?job=$CI_JOB_NAME

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/singleuser:0.3.4-renku0.5.0
+FROM renku/singleuser:0.3.5-renku0.5.2
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src


### PR DESCRIPTION
* Update images to `renku/singleuser:0.3.5-renku0.5.2` - these images don't exist yet, we need to release the new renku-python
* Remove the `dot` section of `.gitlab-ci.yml` since we don't need it anymore
