### PR TITLE
fix: add the renku lockfile to the gitignore template

### DIFF
--- a/R-minimal/.gitignore
+++ b/R-minimal/.gitignore
@@ -373,3 +373,5 @@ tags
 .history
 
 # End of https://www.gitignore.io/api/macos,python,R,linux,vim,emacs,visualstudiocode,intellij
+
+.renku.lock

--- a/python-minimal/.gitignore
+++ b/python-minimal/.gitignore
@@ -373,3 +373,5 @@ tags
 .history
 
 # End of https://www.gitignore.io/api/macos,python,R,linux,vim,emacs,visualstudiocode,intellij
+
+.renku.lock


### PR DESCRIPTION
This PR removes an inconsistency between projects created through the UI and those created through the CLI.
Addresses https://github.com/SwissDataScienceCenter/renku-python/issues/631