### PR TITLE
fix: add .renku/tmp to .gitignore

### DIFF
--- a/R-minimal/.gitignore
+++ b/R-minimal/.gitignore
@@ -264,7 +264,7 @@ ipython_config.py
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
 #Pipfile.lock
 
@@ -374,4 +374,6 @@ tags
 
 # End of https://www.gitignore.io/api/macos,python,R,linux,vim,emacs,visualstudiocode,intellij
 
+# Renku
 .renku.lock
+.renku/tmp

--- a/python-minimal/.gitignore
+++ b/python-minimal/.gitignore
@@ -264,7 +264,7 @@ ipython_config.py
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
 #Pipfile.lock
 
@@ -374,4 +374,6 @@ tags
 
 # End of https://www.gitignore.io/api/macos,python,R,linux,vim,emacs,visualstudiocode,intellij
 
+# Renku
 .renku.lock
+.renku/tmp


### PR DESCRIPTION
Updates `.gitignore` to add `.renku/tmp` directory.

Fixes: https://github.com/SwissDataScienceCenter/renku-python/issues/705

