### PR TITLE
fix: add .renku/cache to .gitignore

### DIFF
--- a/R-minimal/.gitignore
+++ b/R-minimal/.gitignore
@@ -377,3 +377,4 @@ tags
 # Renku
 .renku.lock
 .renku/tmp
+.renku/cache

--- a/python-minimal/.gitignore
+++ b/python-minimal/.gitignore
@@ -377,3 +377,4 @@ tags
 # Renku
 .renku.lock
 .renku/tmp
+.renku/cache


### PR DESCRIPTION
Adds `.renku/cache` to `.gitignore` files for project templates. This directory is used in https://github.com/SwissDataScienceCenter/renku-python/issues/682 to cache remote git repositories.