### PR TITLE
chore: update image versions for release

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/singleuser-r:0.3.7-renku0.5.2
+FROM renku/singleuser-r:0.4.0-renku0.7.0
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/singleuser:0.3.7-renku0.5.2
+FROM renku/singleuser:0.4.0-renku0.7.0
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src


### PR DESCRIPTION
Update images to `renku/singleuser:0.4.0-renku0.7.0` and `renku/singleuser-r:0.4.0-renku0.7.0`.
Images in CI/CD are able to build, `renku --version` and `renku dataset create test` commands work correctly in a project with the python image.

addresses https://github.com/SwissDataScienceCenter/renku/issues/693