### PR TITLE
fix: rename variable names to be valid jinja identifiers

### DIFF
--- a/R-minimal/.renku/metadata.yml
+++ b/R-minimal/.renku/metadata.yml
@@ -5,7 +5,7 @@
   updated: http://schema.org/dateUpdated
   version: http://schema.org/schemaVersion
 '@type': foaf:Project
-created: {{ date-created }}
+created: {{ date_created }}
 name: {{ name }}
-updated: {{ date-updated }}
+updated: {{ date_updated }}
 version: '1'

--- a/python-minimal/.renku/metadata.yml
+++ b/python-minimal/.renku/metadata.yml
@@ -5,7 +5,7 @@
   updated: http://schema.org/dateUpdated
   version: http://schema.org/schemaVersion
 '@type': foaf:Project
-created: {{ date-created }}
+created: {{ date_created }}
 name: {{ name }}
-updated: {{ date-updated }}
+updated: {{ date_updated }}
 version: '1'


### PR DESCRIPTION
Identifiers in Jinja use the Python naming rules, they can't be named with hyphens.

https://jinja.palletsprojects.com/en/master/api/#notes-on-identifiers