### PR TITLE
feat: r package install files

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -3,6 +3,10 @@ FROM renku/singleuser-r:0.4.1-renku0.7.1
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
 
+# install the R dependencies
+COPY install.R /tmp/
+RUN R -f /tmp/install.R
+
 # install the python dependencies
 COPY requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt


### PR DESCRIPTION
Added (1) an `install.R` file to the minimal R template & (2) a few lines in the `Dockerfile` so users can add pkg dependencies to be automatically installed in the docker container, similar to the way requirements.txt is used for python pkg dependencies.