### PR TITLE
fix: update project version

### DIFF
--- a/R-minimal/.renku/metadata.yml
+++ b/R-minimal/.renku/metadata.yml
@@ -8,4 +8,4 @@
 created: {{ date_created }}
 name: {{ name }}
 updated: {{ date_updated }}
-version: '1'
+version: '3'

--- a/python-minimal/.renku/metadata.yml
+++ b/python-minimal/.renku/metadata.yml
@@ -8,4 +8,4 @@
 created: {{ date_created }}
 name: {{ name }}
 updated: {{ date_updated }}
-version: '1'
+version: '3'


### PR DESCRIPTION
Project version needs to be in par with what is set in `renku-python` or otherwise users have to migrate their newly created project right away.