### PR TITLE
build: bump renku-python in images

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -1,6 +1,5 @@
-FROM renku/singleuser-r:0.4.4-renku0.9.0
+FROM renku/renkulab:renku0.10.0-r3.6.1-0.6.0
 
-RUN pipx install renku=='0.9.1' --force 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/renkulab:renku0.9.1-py3.7-0.5.2
+FROM renku/renkulab:renku0.10.0-py3.7-0.6.0
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/renkulab:renku0.9.1-py3.7-0.5.2
+FROM renku/renkulab:renku0.10.0-py3.7-0.6.0
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src


### PR DESCRIPTION
bumped the version of renku-python in the images for the templates
*note*: these images do not exist at the time of PR.