### PR TITLE
bumping renku-python and renkulab-docker tag versions

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/renkulab:renku0.10.0-r3.6.1-0.6.0
+FROM renku/renkulab:renku0.10.1-r3.6.1-0.6.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/renkulab:renku0.10.0-py3.7-0.6.0
+FROM renku/renkulab:renku0.10.1-py3.7-0.6.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/renkulab:renku0.10.0-py3.7-0.6.0
+FROM renku/renkulab:renku0.10.1-py3.7-0.6.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src


### PR DESCRIPTION
bumping versions to be used in the template for the renku-python 0.10.1 release
(before the images are built)