### PR TITLE
chore: remove name variable

### DIFF
--- a/R-minimal/README.md
+++ b/R-minimal/README.md
@@ -1,5 +1,9 @@
 # {{ name }}
 
+{{ description }}
+
+## Introduction
+
 This is a Renku project - basically a git repository with some
 bells and whistles. You'll find we have already created some
 useful things like `data` and `notebooks` directories and

--- a/R-minimal/README.md
+++ b/R-minimal/README.md
@@ -1,7 +1,7 @@
 # {{ name }}
-
+{% if description %}
 {{ description }}
-
+{% endif %}
 ## Introduction
 
 This is a Renku project - basically a git repository with some

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,14 +2,13 @@
   name: Basic Python Project
   description: The simplest Python-based renku project with a basic directory structure and necessary supporting files.
   variables:
-    name: project name, used also in the readme file
+    description: short description added at the beginning of the readme file
 - folder: R-minimal
   name: Basic R Project
   description: The simplest R-based renku project with a basic directory structure and necessary supporting files.
   variables:
-    name: project name, used also in the readme file
+    description: short description added at the beginning of the readme file
 - folder: minimal
   name: Minimal Renku
   description: The simplest renku project template with files for renku CLI and launching projects on renkulab.
-  variables:
-    name: project name
+  variables: {}

--- a/python-minimal/README.md
+++ b/python-minimal/README.md
@@ -1,5 +1,9 @@
 # {{ name }}
 
+{{ description }}
+
+## Introduction
+
 This is a Renku project - basically a git repository with some
 bells and whistles. You'll find we have already created some
 useful things like `data` and `notebooks` directories and

--- a/python-minimal/README.md
+++ b/python-minimal/README.md
@@ -1,7 +1,7 @@
 # {{ name }}
-
+{% if description %}
 {{ description }}
-
+{% endif %}
 ## Introduction
 
 This is a Renku project - basically a git repository with some


### PR DESCRIPTION
Since every project must have a name, we should remove it from the list of variables -- it doesn't make much sense to always require it, plus we may automatically provide a `name` value in `renku init`, making it a "special" parameter.
This is actually done here SwissDataScienceCenter/renku-python#1134

The PR also adds a `description` variable in the `python` and `R` templates.