### PR TITLE
chore: skip submodule checkout in CI

### DIFF
--- a/R-minimal/.gitlab-ci.yml
+++ b/R-minimal/.gitlab-ci.yml
@@ -3,7 +3,6 @@
 variables:
   GIT_STRATEGY: fetch
   GIT_SSL_NO_VERIFY: "true"
-  GIT_SUBMODULE_STRATEGY: recursive
   GIT_LFS_SKIP_SMUDGE: 1
 
 stages:

--- a/minimal/.gitlab-ci.yml
+++ b/minimal/.gitlab-ci.yml
@@ -3,7 +3,6 @@
 variables:
   GIT_STRATEGY: fetch
   GIT_SSL_NO_VERIFY: "true"
-  GIT_SUBMODULE_STRATEGY: recursive
   GIT_LFS_SKIP_SMUDGE: 1
 
 stages:

--- a/python-minimal/.gitlab-ci.yml
+++ b/python-minimal/.gitlab-ci.yml
@@ -3,7 +3,6 @@
 variables:
   GIT_STRATEGY: fetch
   GIT_SSL_NO_VERIFY: "true"
-  GIT_SUBMODULE_STRATEGY: recursive
   GIT_LFS_SKIP_SMUDGE: 1
 
 stages:


### PR DESCRIPTION
Users had problems with the image build failing when their submodules were misconfigured. we shouldn't care about the submodules in CI at all. 