### PR TITLE
chore: bump renku img ver for 0.10.4

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/renkulab:renku0.10.3-r3.6.1-0.6.2
+FROM renku/renkulab-r:4.0.0-renku0.10.4-0.6.3
 # see https://github.com/SwissDataScienceCenter/renkulab-docker
 # to swap this image for the latest version available
 

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/renkulab:renku0.10.3-py3.7-0.6.2
+FROM renku/renkulab-py:3.7-renku0.10.4-0.6.3
 # see https://github.com/SwissDataScienceCenter/renkulab-docker
 # to swap this image for the latest version available
 

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM renku/renkulab:renku0.10.3-py3.7-0.6.2
+FROM renku/renkulab-py:3.7-renku0.10.4-0.6.3
 # see https://github.com/SwissDataScienceCenter/renkulab-docker
 # to swap this image for the latest version available
 


### PR DESCRIPTION
this is the pre-image-build version bump for renku python to use