### PR TITLE
chore: remove comment from glob line

### DIFF
--- a/python-minimal/.renkulfsignore
+++ b/python-minimal/.renkulfsignore
@@ -13,7 +13,9 @@
 # See https://github.com/SwissDataScienceCenter/renku-project-template for proper
 # usage.
 
-*.ipynb # Warning: removing this line will check generated ipynb files (e.g. from papermill) into LFS: they will no longer be displayed in the renku UI
+# Warning: modifying the next line will check generated ipynb files (e.g. from papermill) into LFS: 
+# they will no longer be displayed in the renku UI
+*.ipynb 
 *.py
 *.r
 *.md


### PR DESCRIPTION
Move the comment on its own line - otherwise the file isn't parsed properly (notebooks were getting checked in to LFS). 