### PR TITLE
chore: update image for bugfix

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -1,13 +1,7 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-r:4.0.0-0.7.1
+ARG RENKU_BASE_IMAGE=renku/renkulab-r:4.0.0-0.7.2
 FROM ${RENKU_BASE_IMAGE}
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-
-ARG RENKU_VERSION=0.11.6
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
@@ -30,6 +24,11 @@ RUN R -f /tmp/install.R
 # install the python dependencies
 COPY requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION=0.11.6
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -1,12 +1,6 @@
 # see https://github.com/SwissDataScienceCenter/renkulab-docker
 # to swap this image for the latest version available
-FROM renku/renkulab-bioc:RELEASE_3_11-0.7.1
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-
-ARG RENKU_VERSION=0.11.6
+FROM renku/renkulab-bioc:RELEASE_3_11-0.7.2
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
@@ -29,6 +23,11 @@ RUN R -f /tmp/install.R
 # install the python dependencies
 COPY requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION=0.11.6
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,13 +1,7 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.7-0.7.1
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.7-0.7.2
 FROM ${RENKU_BASE_IMAGE}
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-
-ARG RENKU_VERSION=0.11.6
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
@@ -34,6 +28,11 @@ ARG RENKU_VERSION=0.11.6
 #    /opt/conda/bin/pip install -r /tmp/requirements.txt && \
 #    conda clean -y --all && \
 #    conda env export -n "root"
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION=0.11.6
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,13 +1,7 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.7-0.7.1
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.7-0.7.2
 FROM ${RENKU_BASE_IMAGE}
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-
-ARG RENKU_VERSION=0.11.6
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
@@ -29,6 +23,11 @@ RUN conda env update -q -f /tmp/environment.yml && \
     /opt/conda/bin/pip install -r /tmp/requirements.txt && \
     conda clean -y --all && \
     conda env export -n "root"
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION=0.11.6
 
 ########################################################
 # Do not edit this section and do not add anything below


### PR DESCRIPTION
Update to 0.7.2 to include the PATH bugfix. Also, rearranges the Dockerfile slightly to put the renku-python version at the bottom so as to not trigger a rebuild of the whole image if all that is needed is a renku-python change. 