### PR TITLE
chore: update template for 0.12.0

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -28,9 +28,14 @@ RUN pip3 install -r /tmp/requirements.txt
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.11.6
+ARG RENKU_VERSION=0.12.0
 
 ########################################################
 # Do not edit this section and do not add anything below
-RUN pipx install --force renku==${RENKU_VERSION}
+
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    pipx uninstall renku && \
+    pipx install --force renku==${RENKU_VERSION} \
+    ; fi
+
 ########################################################

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -27,9 +27,14 @@ RUN pip3 install -r /tmp/requirements.txt
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.11.6
+ARG RENKU_VERSION=0.12.0
 
 ########################################################
 # Do not edit this section and do not add anything below
-RUN pipx install --force renku==${RENKU_VERSION}
+
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    pipx uninstall renku && \
+    pipx install --force renku==${RENKU_VERSION} \
+    ; fi
+
 ########################################################

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -32,9 +32,14 @@ FROM ${RENKU_BASE_IMAGE}
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.11.6
+ARG RENKU_VERSION=0.12.0
 
 ########################################################
 # Do not edit this section and do not add anything below
-RUN pipx install --force renku==${RENKU_VERSION}
+
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    pipx uninstall renku && \
+    pipx install --force renku==${RENKU_VERSION} \
+    ; fi
+
 ########################################################

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -27,9 +27,14 @@ RUN conda env update -q -f /tmp/environment.yml && \
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.11.6
+ARG RENKU_VERSION=0.12.0
 
 ########################################################
 # Do not edit this section and do not add anything below
-RUN pipx install --force renku==${RENKU_VERSION}
+
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    pipx uninstall renku && \
+    pipx install --force renku==${RENKU_VERSION} \
+    ; fi
+
 ########################################################


### PR DESCRIPTION
This updates the template for renku-python 0.12.0 and introduces some extra logic to prevent unnecessary installations