### PR TITLE
chore: remove R specific patterns from python template .gitignore

### DIFF
--- a/python-minimal/.gitignore
+++ b/python-minimal/.gitignore
@@ -301,48 +301,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-### R ###
-# History files
-.Rhistory
-.Rapp.history
-
-# Session Data files
-.RData
-
-# User-specific files
-.Ruserdata
-
-# Example code in package build process
-*-Ex.R
-
-# Output files from R CMD build
-/*.tar.gz
-
-# Output files from R CMD check
-/*.Rcheck/
-
-# RStudio files
-.Rproj.user/
-
-# produced vignettes
-vignettes/*.html
-vignettes/*.pdf
-
-# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
-.httr-oauth
-
-# knitr and R markdown default cache directories
-/*_cache/
-/cache/
-
-# Temporary files created by R markdown
-*.utf8.md
-*.knit.md
-
-### R.Bookdown Stack ###
-# R package: bookdown caching files
-/*_files/
-
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]


### PR DESCRIPTION
removes all R-specific patterns from the python template `.gitignore`