### PR TITLE
chore: update Renku CLI version

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -28,7 +28,7 @@ RUN pip3 install -r /tmp/requirements.txt
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.14.1
+ARG RENKU_VERSION=0.14.2
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -27,7 +27,7 @@ RUN pip3 install -r /tmp/requirements.txt
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.14.1
+ARG RENKU_VERSION=0.14.2
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -32,7 +32,7 @@ FROM ${RENKU_BASE_IMAGE}
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.14.1
+ARG RENKU_VERSION=0.14.2
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -27,7 +27,7 @@ RUN conda env update -q -f /tmp/environment.yml && \
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.14.1
+ARG RENKU_VERSION=0.14.2
 
 ########################################################
 # Do not edit this section and do not add anything below


### PR DESCRIPTION
Following a discussion we agreed to make the version templatable (issue https://github.com/SwissDataScienceCenter/renku-python/issues/2025)  but until this is done we still need to update it manually.