### PR TITLE
chore: update julia template

### DIFF
--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -1,6 +1,7 @@
-FROM renku/renkulab-julia:1.4.2-renku0.10.4-a31920c
-# see https://github.com/SwissDataScienceCenter/renkulab-docker
-# to swap this image for the latest version available
+# For finding latest versions of the base image see
+# https://github.com/SwissDataScienceCenter/renkulab-docker
+ARG RENKU_BASE_IMAGE=renku/renkulab-julia:1.5.3-0.7.5
+FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
@@ -28,3 +29,18 @@ COPY Project.toml Manifest.toml /tmp/
 RUN mkdir /tmp/julia-pkg && \
     cp /tmp/Project.toml /tmp/Manifest.toml /tmp/julia-pkg/ && \
     julia -e'using Pkg; Pkg.activate("/tmp/julia-pkg/"); Pkg.instantiate(); Pkg.precompile()'
+    
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION=0.14.2
+
+########################################################
+# Do not edit this section and do not add anything below
+
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    pipx uninstall renku && \
+    pipx install --force renku==${RENKU_VERSION} \
+    ; fi
+
+########################################################


### PR DESCRIPTION
- Updates the julia minimal template to be in line with the other templates. 
- Adds the base image argument like the others
- Only defaults to 1.5.3 but could update to 1.6.1 later on

closes #102 