### PR TITLE
feat: use templated renku version

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -28,7 +28,7 @@ RUN pip3 install -r /tmp/requirements.txt
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.15.1
+ARG RENKU_VERSION={{ __renku_version__ | default("0.15.1") }}
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # renku-project-template
-A repository to hold template files for new Renku projects to be used on project
-creation by the Renku clients. The next sections outline what different files in
-the template are used for.
 
-
+A repository of base templates for new Renku projects. The next sections outline
+what different files in the template are used for.
 ## For running interactive environments from Renkulab
 
 `Dockerfile` - File for building a docker image that you can launch from renkulab,
@@ -21,6 +19,22 @@ out of the project on `git push` to renkulab so that you can launch your interac
 `.dockerignore` - Files and directories to be excluded from docker build (you can
   append to this list); https://docs.docker.com/engine/reference/builder/#dockerignore-file.
 
+### Setting the version of the renku-cli
+
+The default version of the renku CLI used in the interactive environment is
+specified in the Dockerfile in a line similar to this:
+
+```
+ARG RENKU_VERSION={{ __renku_version__ | default("0.15.1") }}
+```
+
+The client creating the project (either via the UI in RenkuLab or the renku CLI)
+can override this default setting. The version is set as follows:
+
+* if the client (the renku core service or the renku CLI) is using a released
+  version, then pass this to the project template
+* if the client is on a development version, use the default provided by the
+  template
 
 ## For managing software dependencies
 

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -27,7 +27,7 @@ RUN pip3 install -r /tmp/requirements.txt
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.15.1
+ARG RENKU_VERSION={{ __renku_version__ | default("0.15.1") }}
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir /tmp/julia-pkg && \
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.15.1
+ARG RENKU_VERSION={{ __renku_version__ | default("0.15.1") }}
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -32,7 +32,7 @@ FROM ${RENKU_BASE_IMAGE}
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.15.1
+ARG RENKU_VERSION={{ __renku_version__ | default("0.15.1") }}
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -27,7 +27,7 @@ RUN conda env update -q -f /tmp/environment.yml && \
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION=0.15.1
+ARG RENKU_VERSION={{ __renku_version__ | default("0.15.1") }}
 
 ########################################################
 # Do not edit this section and do not add anything below


### PR DESCRIPTION
This PR makes it possible to inject a version of the renku CLI at the time of project creation. This ensures that in production settings new projects are always created with the same version of renku-python as is used by the core service, to avoid unnecessary migrations on brand new projects. 

To test you need renku-python from commit `38978f` onwards. 