### PR TITLE
chore: update base docker images

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-r:4.0.5-0.8.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-r:4.0.5-0.9.0
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # see https://github.com/SwissDataScienceCenter/renkulab-docker
 # to swap this image for the latest version available
-FROM renku/renkulab-bioc:RELEASE_3_12-0.8.0
+FROM renku/renkulab-bioc:RELEASE_3_12-0.9.0
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-julia:1.6.1-0.8.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-julia:1.6.1-0.9.0
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 - folder: python-minimal
-  name: Basic Python (3.8) Project
-  description: The simplest Python-3.8-based renku project with a basic directory structure and necessary supporting files.
+  name: Basic Python (3.9) Project
+  description: The simplest Python-3.9-based renku project with a basic directory structure and necessary supporting files.
   variables:
     description: short description added at the beginning of the readme file
 - folder: R-minimal

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.8.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.9.0
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.8-0.8.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.8.0
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.8.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.9.0
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.8-0.8.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.8.0
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image


### PR DESCRIPTION
The base docker renkulab images were upgraded from 0.8.0 to 0.9.0 after Python 3.9 was rolled out by JupyterLab 3.0.