### PR TITLE
chore: update default rp version

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -28,7 +28,7 @@ RUN pip3 install -r /tmp/requirements.txt
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.1.2") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("1.2.4") }}
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -27,7 +27,7 @@ RUN pip3 install -r /tmp/requirements.txt
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.1.2") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("1.2.4") }}
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir /tmp/julia-pkg && \
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.1.2") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("1.2.4") }}
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -32,7 +32,7 @@ FROM ${RENKU_BASE_IMAGE}
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.1.2") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("1.2.4") }}
 
 ########################################################
 # Do not edit this section and do not add anything below

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -27,7 +27,7 @@ RUN conda env update -q -f /tmp/environment.yml && \
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.1.2") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("1.2.4") }}
 
 ########################################################
 # Do not edit this section and do not add anything below


### PR DESCRIPTION
Update default renku python version to avoid incompat issues when initializing from CLI. 