### PR TITLE
style(container-build): add comments to `install.R` to help users understand what can go in this file

### DIFF
--- a/R-minimal/install.R
+++ b/R-minimal/install.R
@@ -1,0 +1,9 @@
+# This file contains packages which should be added to the notebook
+# during the build process. It is standard R code which is run during
+# the build process and typically comprises a set of `install.packages()`
+# commands.
+#
+# For example, remove the comment from the line below if you wish to
+# install the `ggplot2` package.
+#
+# install.packages('ggplot2')


### PR DESCRIPTION
When testing the containerized gitlab runners, I needed to test with an R-based project; I did not know how this works and in particular how to add packages etc. For me, a comment in `install.R` such as that included in this PR have been helpful.