### PR TITLE
chore: update images to renkulab-docker 0.13.1

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-r:4.2.0-0.12.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-r:4.2.0-0.13.1
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # see https://github.com/SwissDataScienceCenter/renkulab-docker
 # to swap this image for the latest version available
-FROM renku/renkulab-bioc:RELEASE_3_15-0.12.0
+FROM renku/renkulab-bioc:RELEASE_3_15-0.13.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-julia:1.7.1-0.12.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-julia:1.7.1-0.13.1
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.12.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.13.1
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,6 +1,6 @@
 # For finding latest versions of the base image see
 # https://github.com/SwissDataScienceCenter/renkulab-docker
-ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.12.0
+ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.13.1
 FROM ${RENKU_BASE_IMAGE}
 
 # Uncomment and adapt if code is to be included in the image


### PR DESCRIPTION
This is so that our new project templates use the latest version of our images.