### PR TITLE
chore: restructure dockerfile for better build performance

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -3,6 +3,31 @@
 ARG RENKU_BASE_IMAGE=renku/renkulab-r:4.2.0-0.13.1
 FROM ${RENKU_BASE_IMAGE}
 
+########################################################
+#        Renku install section - do not edit           #
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+
+# Install renku from pypi or from github if a dev version
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    source .renku/venv/bin/activate ; \
+    currentversion=$(renku --version) ; \
+    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+    pip uninstall renku -y ; \
+    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+    if [ -n "$gitversion" ] ; then \
+    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+    else \
+    pip install --force renku==${RENKU_VERSION} ;\
+    fi \
+    fi \
+    fi
+#             End renku install section                #
+########################################################
+
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
 
@@ -24,28 +49,3 @@ RUN R -f /tmp/install.R
 # install the python dependencies
 COPY requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
-
-########################################################
-# Do not edit this section and do not add anything below
-
-# Install renku from pypi or from github if it's a dev version
-RUN if [ -n "$RENKU_VERSION" ] ; then \
-        source .renku/venv/bin/activate ; \
-        currentversion=$(renku --version) ; \
-        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-            pip uninstall renku -y ; \
-            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-            if [ -n "$gitversion" ] ; then \
-                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-            else \
-                pip install --force renku==${RENKU_VERSION} ;\
-            fi \
-        fi \
-    fi
-
-########################################################

--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -9,21 +9,21 @@ FROM ${RENKU_BASE_IMAGE}
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("2.0.0") }}
 
 # Install renku from pypi or from github if a dev version
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    source .renku/venv/bin/activate ; \
-    currentversion=$(renku --version) ; \
-    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-    pip uninstall renku -y ; \
-    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-    if [ -n "$gitversion" ] ; then \
-    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-    else \
-    pip install --force renku==${RENKU_VERSION} ;\
-    fi \
-    fi \
+        source .renku/venv/bin/activate ; \
+        currentversion=$(renku --version) ; \
+        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+            pip uninstall renku -y ; \
+            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+            if [ -n "$gitversion" ] ; then \
+                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+            else \
+                pip install --force renku==${RENKU_VERSION} ;\
+            fi \
+        fi \
     fi
 #             End renku install section                #
 ########################################################

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -2,6 +2,32 @@
 # to swap this image for the latest version available
 FROM renku/renkulab-bioc:RELEASE_3_15-0.13.1
 
+########################################################
+#        Renku install section - do not edit           #
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+
+# Install renku from pypi or from github if a dev version
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    source .renku/venv/bin/activate ; \
+    currentversion=$(renku --version) ; \
+    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+    pip uninstall renku -y ; \
+    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+    if [ -n "$gitversion" ] ; then \
+    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+    else \
+    pip install --force renku==${RENKU_VERSION} ;\
+    fi \
+    fi \
+    fi
+#             End renku install section                #
+########################################################
+
+
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
 
@@ -23,28 +49,3 @@ RUN R -f /tmp/install.R
 # install the python dependencies
 COPY requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
-
-########################################################
-# Do not edit this section and do not add anything below
-
-# Install renku from pypi or from github if it's a dev version
-RUN if [ -n "$RENKU_VERSION" ] ; then \
-        source .renku/venv/bin/activate ; \
-        currentversion=$(renku --version) ; \
-        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-            pip uninstall renku -y ; \
-            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-            if [ -n "$gitversion" ] ; then \
-                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-            else \
-                pip install --force renku==${RENKU_VERSION} ;\
-            fi \
-        fi \
-    fi
-
-########################################################

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -8,21 +8,21 @@ FROM renku/renkulab-bioc:RELEASE_3_15-0.13.1
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("2.0.0") }}
 
 # Install renku from pypi or from github if a dev version
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    source .renku/venv/bin/activate ; \
-    currentversion=$(renku --version) ; \
-    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-    pip uninstall renku -y ; \
-    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-    if [ -n "$gitversion" ] ; then \
-    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-    else \
-    pip install --force renku==${RENKU_VERSION} ;\
-    fi \
-    fi \
+        source .renku/venv/bin/activate ; \
+        currentversion=$(renku --version) ; \
+        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+            pip uninstall renku -y ; \
+            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+            if [ -n "$gitversion" ] ; then \
+                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+            else \
+                pip install --force renku==${RENKU_VERSION} ;\
+            fi \
+        fi \
     fi
 #             End renku install section                #
 ########################################################

--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -44,10 +44,10 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 
 # install the python dependencies
 COPY requirements.txt environment.yml /tmp/
-RUN conda env update -q -f /tmp/environment.yml && \
+RUN mamba env update -q -f /tmp/environment.yml && \
     /opt/conda/bin/pip install -r /tmp/requirements.txt && \
-    conda clean -y --all && \
-    conda env export -n "root"
+    mamba clean -y --all && \
+    mamba env export -n "root"
 
 # download and precompile any libaries to speed up startup time
 COPY Project.toml Manifest.toml /tmp/

--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -3,6 +3,31 @@
 ARG RENKU_BASE_IMAGE=renku/renkulab-julia:1.7.1-0.13.1
 FROM ${RENKU_BASE_IMAGE}
 
+########################################################
+#        Renku install section - do not edit           #
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+
+# Install renku from pypi or from github if a dev version
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    source .renku/venv/bin/activate ; \
+    currentversion=$(renku --version) ; \
+    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+    pip uninstall renku -y ; \
+    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+    if [ -n "$gitversion" ] ; then \
+    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+    else \
+    pip install --force renku==${RENKU_VERSION} ;\
+    fi \
+    fi \
+    fi
+#             End Renku install section                #
+########################################################
+
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
 
@@ -29,28 +54,3 @@ COPY Project.toml Manifest.toml /tmp/
 RUN mkdir /tmp/julia-pkg && \
     cp /tmp/Project.toml /tmp/Manifest.toml /tmp/julia-pkg/ && \
     julia -e'using Pkg; Pkg.activate("/tmp/julia-pkg/"); Pkg.instantiate(); Pkg.precompile()'
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
-
-########################################################
-# Do not edit this section and do not add anything below
-
-# Install renku from pypi or from github if it's a dev version
-RUN if [ -n "$RENKU_VERSION" ] ; then \
-        source .renku/venv/bin/activate ; \
-        currentversion=$(renku --version) ; \
-        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-            pip uninstall renku -y ; \
-            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-            if [ -n "$gitversion" ] ; then \
-                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-            else \
-                pip install --force renku==${RENKU_VERSION} ;\
-            fi \
-        fi \
-    fi
-
-########################################################

--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -9,21 +9,21 @@ FROM ${RENKU_BASE_IMAGE}
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("2.0.0") }}
 
 # Install renku from pypi or from github if a dev version
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    source .renku/venv/bin/activate ; \
-    currentversion=$(renku --version) ; \
-    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-    pip uninstall renku -y ; \
-    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-    if [ -n "$gitversion" ] ; then \
-    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-    else \
-    pip install --force renku==${RENKU_VERSION} ;\
-    fi \
-    fi \
+        source .renku/venv/bin/activate ; \
+        currentversion=$(renku --version) ; \
+        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+            pip uninstall renku -y ; \
+            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+            if [ -n "$gitversion" ] ; then \
+                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+            else \
+                pip install --force renku==${RENKU_VERSION} ;\
+            fi \
+        fi \
     fi
 #             End Renku install section                #
 ########################################################

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -3,6 +3,31 @@
 ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.13.1
 FROM ${RENKU_BASE_IMAGE}
 
+########################################################
+#        Renku install section - do not edit           #
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+
+# Install renku from pypi or from github if a dev version
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    source .renku/venv/bin/activate ; \
+    currentversion=$(renku --version) ; \
+    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+    pip uninstall renku -y ; \
+    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+    if [ -n "$gitversion" ] ; then \
+    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+    else \
+    pip install --force renku==${RENKU_VERSION} ;\
+    fi \
+    fi \
+    fi
+#             End renku install section                #
+########################################################
+
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
 
@@ -28,28 +53,3 @@ FROM ${RENKU_BASE_IMAGE}
 #    /opt/conda/bin/pip install -r /tmp/requirements.txt && \
 #    conda clean -y --all && \
 #    conda env export -n "root"
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
-
-########################################################
-# Do not edit this section and do not add anything below
-
-# Install renku from pypi or from github if it's a dev version
-RUN if [ -n "$RENKU_VERSION" ] ; then \
-        source .renku/venv/bin/activate ; \
-        currentversion=$(renku --version) ; \
-        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-            pip uninstall renku -y ; \
-            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-            if [ -n "$gitversion" ] ; then \
-                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-            else \
-                pip install --force renku==${RENKU_VERSION} ;\
-            fi \
-        fi \
-    fi
-
-########################################################

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -9,21 +9,21 @@ FROM ${RENKU_BASE_IMAGE}
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("2.0.0") }}
 
 # Install renku from pypi or from github if a dev version
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    source .renku/venv/bin/activate ; \
-    currentversion=$(renku --version) ; \
-    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-    pip uninstall renku -y ; \
-    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-    if [ -n "$gitversion" ] ; then \
-    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-    else \
-    pip install --force renku==${RENKU_VERSION} ;\
-    fi \
-    fi \
+        source .renku/venv/bin/activate ; \
+        currentversion=$(renku --version) ; \
+        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+            pip uninstall renku -y ; \
+            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+            if [ -n "$gitversion" ] ; then \
+                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+            else \
+                pip install --force renku==${RENKU_VERSION} ;\
+            fi \
+        fi \
     fi
 #             End renku install section                #
 ########################################################

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -10,21 +10,21 @@ FROM ${RENKU_BASE_IMAGE}
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
 # visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+ARG RENKU_VERSION={{ __renku_version__ | default("2.0.0") }}
 
 # Install renku from pypi or from github if a dev version
 RUN if [ -n "$RENKU_VERSION" ] ; then \
-    source .renku/venv/bin/activate ; \
-    currentversion=$(renku --version) ; \
-    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-    pip uninstall renku -y ; \
-    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-    if [ -n "$gitversion" ] ; then \
-    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-    else \
-    pip install --force renku==${RENKU_VERSION} ;\
-    fi \
-    fi \
+        source .renku/venv/bin/activate ; \
+        currentversion=$(renku --version) ; \
+        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+            pip uninstall renku -y ; \
+            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+            if [ -n "$gitversion" ] ; then \
+                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+            else \
+                pip install --force renku==${RENKU_VERSION} ;\
+            fi \
+        fi \
     fi
 #             End renku install section                #
 ########################################################

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -45,7 +45,7 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 
 # install the python dependencies
 COPY requirements.txt environment.yml /tmp/
-RUN conda env update -q -f /tmp/environment.yml && \
+RUN mamba env update -q -f /tmp/environment.yml && \
     /opt/conda/bin/pip install -r /tmp/requirements.txt && \
-    conda clean -y --all && \
-    conda env export -n "root"
+    mamba clean -y --all && \
+    mamba env export -n "root"

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -3,6 +3,32 @@
 ARG RENKU_BASE_IMAGE=renku/renkulab-py:3.9-0.13.1
 FROM ${RENKU_BASE_IMAGE}
 
+
+########################################################
+#        Renku install section - do not edit           #
+
+# RENKU_VERSION determines the version of the renku CLI
+# that will be used in this image. To find the latest version,
+# visit https://pypi.org/project/renku/#history.
+ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
+
+# Install renku from pypi or from github if a dev version
+RUN if [ -n "$RENKU_VERSION" ] ; then \
+    source .renku/venv/bin/activate ; \
+    currentversion=$(renku --version) ; \
+    if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
+    pip uninstall renku -y ; \
+    gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
+    if [ -n "$gitversion" ] ; then \
+    pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
+    else \
+    pip install --force renku==${RENKU_VERSION} ;\
+    fi \
+    fi \
+    fi
+#             End renku install section                #
+########################################################
+
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src
 
@@ -23,28 +49,3 @@ RUN conda env update -q -f /tmp/environment.yml && \
     /opt/conda/bin/pip install -r /tmp/requirements.txt && \
     conda clean -y --all && \
     conda env export -n "root"
-
-# RENKU_VERSION determines the version of the renku CLI
-# that will be used in this image. To find the latest version,
-# visit https://pypi.org/project/renku/#history.
-ARG RENKU_VERSION={{ __renku_version__ | default("1.6.0") }}
-
-########################################################
-# Do not edit this section and do not add anything below
-
-# Install renku from pypi or from github if it's a dev version
-RUN if [ -n "$RENKU_VERSION" ] ; then \
-        source .renku/venv/bin/activate ; \
-        currentversion=$(renku --version) ; \
-        if [ "$RENKU_VERSION" != "$currentversion" ] ; then \
-            pip uninstall renku -y ; \
-            gitversion=$(echo "$RENKU_VERSION" | sed -n "s/^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(rc[[:digit:]]\+\)*\(\.dev[[:digit:]]\+\)*\(+g\([a-f0-9]\+\)\)*\(+dirty\)*$/\4/p") ; \
-            if [ -n "$gitversion" ] ; then \
-                pip install --force "git+https://github.com/SwissDataScienceCenter/renku-python.git@$gitversion" ;\
-            else \
-                pip install --force renku==${RENKU_VERSION} ;\
-            fi \
-        fi \
-    fi
-
-########################################################


### PR DESCRIPTION
This PR moves the section of the Dockerfile that installs the renku-CLI to the top so that it can make better use of caching. 

In addition, it switches to using mamba instead of conda for faster builds. 