### PR TITLE
chore: fix bad venv setup

### DIFF
--- a/R/Dockerfile
+++ b/R/Dockerfile
@@ -51,6 +51,7 @@ RUN R -f /tmp/install.R
 
 # install the python dependencies
 COPY requirements.txt /tmp/
-RUN pip3 install -r /tmp/requirements.txt --no-cache-dir
+RUN pip3 install -r /tmp/requirements.txt --no-cache-dir && \
+    rm -rf ${HOME}/.renku/venv
 
 COPY --from=builder ${HOME}/.renku/venv ${HOME}/.renku/venv

--- a/bioc/Dockerfile
+++ b/bioc/Dockerfile
@@ -51,6 +51,7 @@ RUN R -f /tmp/install.R
 
 # install the python dependencies
 COPY requirements.txt /tmp/
-RUN pip3 install -r /tmp/requirements.txt --no-cache-dir
+RUN pip3 install -r /tmp/requirements.txt --no-cache-dir && \
+    rm -rf ${HOME}/.renku/venv
 
 COPY --from=builder ${HOME}/.renku/venv ${HOME}/.renku/venv

--- a/julia/Dockerfile
+++ b/julia/Dockerfile
@@ -56,6 +56,7 @@ RUN mamba env update -q -f /tmp/environment.yml && \
 COPY Project.toml Manifest.toml /tmp/
 RUN mkdir /tmp/julia-pkg && \
     cp /tmp/Project.toml /tmp/Manifest.toml /tmp/julia-pkg/ && \
-    julia -e'using Pkg; Pkg.activate("/tmp/julia-pkg/"); Pkg.instantiate(); Pkg.precompile()'
+    julia -e'using Pkg; Pkg.activate("/tmp/julia-pkg/"); Pkg.instantiate(); Pkg.precompile()' && \
+    rm -rf ${HOME}/.renku/venv
 
 COPY --from=builder ${HOME}/.renku/venv ${HOME}/.renku/venv

--- a/minimal/Dockerfile
+++ b/minimal/Dockerfile
@@ -57,4 +57,6 @@ FROM ${RENKU_BASE_IMAGE}
 #    conda clean -y --all && \
 #    conda env export -n "root"
 
+RUN rm -rf ${HOME}/.renku/venv
+
 COPY --from=builder ${HOME}/.renku/venv ${HOME}/.renku/venv

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -50,6 +50,7 @@ COPY requirements.txt environment.yml /tmp/
 RUN mamba env update -q -f /tmp/environment.yml && \
     /opt/conda/bin/pip install -r /tmp/requirements.txt --no-cache-dir && \
     mamba clean -y --all && \
-    mamba env export -n "root"
+    mamba env export -n "root" && \
+    rm -rf ${HOME}/.renku/venv
 
 COPY --from=builder ${HOME}/.renku/venv ${HOME}/.renku/venv


### PR DESCRIPTION
The line 

```
COPY --from builder ${HOME}/.renku/venv ${HOME}/.renku/venv
```

does not replace the contents but simply adds to it, leading to a bad state of the packages in the virtualenv. This PR fixes this by brute force - removing the directory beforehand. A symptom of this was the `renku` CLI complaining about a bad version of the `cwltool`, e.g. 

```
You are using cwltool version 3.1.20211107152837, which might not be compatible with version 3.1.20220628170238 used by Toil. You should consider running 'pip install cwltool==3.1.20220628170238' to match Toil's cwltool version.
```

In a [project created with this template](https://dev.renku.ch/projects/rokroskar/test-dockerfile-fix), no such warning/error is generated:

<img width="916" alt="image" src="https://user-images.githubusercontent.com/3353586/216156310-86885ba9-76c2-492f-a2a4-a898b2d6561f.png">


