### PR TITLE
chore: bump bioc base image

### DIFF
--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 #        Renku install section - do not edit           #
 
-FROM renku/renkulab-bioc:RELEASE_3_15-0.15.1 as builder
+FROM renku/renkulab-bioc:RELEASE_3_17-0.16.0 as builder
 
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
@@ -25,7 +25,7 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 #             End Renku install section                #
 ########################################################
 
-FROM renku/renkulab-bioc:RELEASE_3_15-0.15.1
+FROM renku/renkulab-bioc:RELEASE_3_17-0.16.0
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 #        Renku install section - do not edit           #
 
-FROM renku/renkulab-bioc:RELEASE_3_15-0.14.0 as builder
+FROM renku/renkulab-bioc:RELEASE_3_15-0.15.0 as builder
 
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
@@ -25,7 +25,7 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 #             End Renku install section                #
 ########################################################
 
-FROM renku/renkulab-bioc:RELEASE_3_15-0.14.0
+FROM renku/renkulab-bioc:RELEASE_3_15-0.15.0
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 #        Renku install section - do not edit           #
 
-FROM renku/renkulab-bioc:RELEASE_3_15-0.15.0 as builder
+FROM renku/renkulab-bioc:RELEASE_3_15-0.15.1 as builder
 
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
@@ -25,7 +25,7 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 #             End Renku install section                #
 ########################################################
 
-FROM renku/renkulab-bioc:RELEASE_3_15-0.15.0
+FROM renku/renkulab-bioc:RELEASE_3_15-0.15.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src


### PR DESCRIPTION
bumps the bioc base image - for some reason the dependabot update doesn't work on these (yet)