### PR TITLE
chore: revert "use template variables for language versions (#198)"

### DIFF
--- a/R-minimal/Dockerfile
+++ b/R-minimal/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 #        Renku install section - do not edit           #
 
-FROM renku/renkulab-r:{{ R_version | default("4.2.0") }}-0.18.1 as builder
+FROM renku/renkulab-r:4.2.0-0.18.1 as builder
 
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
@@ -25,7 +25,7 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 #             End Renku install section                #
 ########################################################
 
-FROM renku/renkulab-r:{{ R_version | default("4.2.0") }}-0.18.1
+FROM renku/renkulab-r:4.2.0-0.18.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/bioc-minimal/Dockerfile
+++ b/bioc-minimal/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 #        Renku install section - do not edit           #
 
-FROM renku/renkulab-bioc:RELEASE_{{ bioc_version | default("3_17") }}-0.18.1 as builder
+FROM renku/renkulab-bioc:RELEASE_3_17-0.18.1 as builder
 
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
@@ -25,7 +25,7 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 #             End Renku install section                #
 ########################################################
 
-FROM renku/renkulab-bioc:RELEASE_{{ bioc_version | default("3_17") }}-0.18.1
+FROM renku/renkulab-bioc:RELEASE_3_17-0.18.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/julia-minimal/Dockerfile
+++ b/julia-minimal/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 #        Renku install section - do not edit           #
 
-FROM renku/renkulab-julia:{{ julia_version | default("1.9.0") }}-0.18.1 as builder
+FROM renku/renkulab-julia:1.9.0-0.18.1 as builder
 
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
@@ -25,7 +25,7 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 #             End Renku install section                #
 ########################################################
 
-FROM renku/renkulab-julia:{{ julia_version | default("1.9.0") }}-0.18.1
+FROM renku/renkulab-julia:1.9.0-0.18.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,61 +1,25 @@
 - folder: python-minimal
-  name: Python
+  name: Python (3.10) Project
   description: A Python Renku project.
-  variables: 
-    python_version: 
-      description: Set the Python version.
-      default_value: "3.10"
-      type: enum
-      enum: 
-        - "3.8"
-        - "3.9"
-        - "3.10"
+  variables: {}
   icon: python-minimal.png
   ssh_supported: true
 - folder: R-minimal
-  name: R
+  name: R (4.2.0) Project
   description: An R Renku project.
-  variables: 
-    R_version: 
-      description: Set the R version.
-      default_value: "4.2.0"
-      type: enum
-      enum: 
-        - "4.1.0"
-        - "4.1.1"
-        - "4.1.2"
-        - "4.2.0"
-        - "devel"
+  variables: {}
   icon: R-minimal.png
   ssh_supported: true
 - folder: bioc-minimal
-  name: Bioconductor
-  description: An R-Bioconductor Renku project.
-  variables:
-    bioc_version: 
-      description: Set the Bioconductor version.
-      default_value: "3_17"
-      type: enum
-      enum: 
-        - "3_14"
-        - "3_15"
-        - "3_16"
-        - "3_17"
-        - "devel"
+  name: R-Bioconductor (3.17) Project
+  description: An R bioconductor Renku project.
+  variables: {}
   icon: bioconductor.png
   ssh_supported: true
 - folder: julia-minimal
-  name: Julia
+  name: Julia (1.9.0) Project
   description: A Julia Renku project.
-  variables:
-    julia_version: 
-      description: Set the Bioconductor version.
-      default_value: "1.9.0"
-      type: enum
-      enum: 
-        - "1.7.1"
-        - "1.8.5"
-        - "1.9.0"
+  variables: {}
   icon: julialang.png
   ssh_supported: true
 - folder: minimal

--- a/python-minimal/Dockerfile
+++ b/python-minimal/Dockerfile
@@ -1,7 +1,7 @@
 ########################################################
 #        Renku install section - do not edit           #
 
-FROM renku/renkulab-py:{{ python_version | default("3.10") }}-0.18.1 as builder
+FROM renku/renkulab-py:3.10-0.18.1 as builder
 
 # RENKU_VERSION determines the version of the renku CLI
 # that will be used in this image. To find the latest version,
@@ -25,7 +25,7 @@ RUN if [ -n "$RENKU_VERSION" ] ; then \
 #             End Renku install section                #
 ########################################################
 
-FROM renku/renkulab-py:{{ python_version | default("3.10") }}-0.18.1
+FROM renku/renkulab-py:3.10-0.18.1
 
 # Uncomment and adapt if code is to be included in the image
 # COPY src /code/src


### PR DESCRIPTION
This reverts commit 56aa0a25cc8d7c5133e2933e9fed10a87f95f5fd.

Templating the language versions introduces a few complications: 

1. no longer possible to automatically update the base images in this repo
2. when automatically updating a project, we may inadvertently update the version of R or python in the project

Until we have a way of preventing the latter, we should not roll out the templating. 